### PR TITLE
Update gitignore so build file changes don't appear in commit diffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
 /logs/
 .idea/
+
+# Netbeans project files
+nbproject
+tools/MapleCouponInstaller/nbproject
+tools/MapleIdRetriever/nbproject
+tools/MobBookIndexer/nbproject
+tools/MobBookUpdate/nbproject
+
+# build files
+build
+tools/MapleCouponInstaller/build
+tools/MapleIdRetriever/build
+tools/MobBookIndexer/build
+tools/MobBookUpdate/build


### PR DESCRIPTION
Try merging this so that when you commit changes, you don't get the spam of the java .class files in the changes tab for people looking at what you changed in the code.

Also, did you see my comment about using HikariCP database pool instead of DBCP ? Just look at the benchmarks and reviews. https://github.com/brettwooldridge/HikariCP

Thanks for your contributions to the maple community Ronan!