### PR TITLE
Typo in MaplePacketCreator.java

### DIFF
--- a/src/tools/MaplePacketCreator.java
+++ b/src/tools/MaplePacketCreator.java
@@ -7069,7 +7069,7 @@ public class MaplePacketCreator {
 
         public static byte[] CPQDied(MapleCharacter chr) {
                 final MaplePacketLittleEndianWriter mplew = new MaplePacketLittleEndianWriter();
-                mplew.writeShort(SendOpcode.MONSTER_CARNIVAL_SUMMON.getValue());
+                mplew.writeShort(SendOpcode.MONSTER_CARNIVAL_DIED.getValue());
                 mplew.write(chr.getTeam()); //Team
                 mplew.writeMapleAsciiString(chr.getName()); //Name of the player that died
                 mplew.write(chr.getAndRemoveCP()); //Lost CP


### PR DESCRIPTION
Fixed incorrect OPcode in CPQ that caused an error 38 when a player dies.