### PR TITLE
WZPath Property Change

### DIFF
--- a/src/net/server/Server.java
+++ b/src/net/server/Server.java
@@ -365,6 +365,7 @@ public class Server implements Runnable {
     }
 
     public static void main(String args[]) {
+	System.setProperty("wzpath", "wz");
         Server.getInstance().run();
     }
 


### PR DESCRIPTION
Allows hotcode placement due to IDE's unable being able to find WZ files loading from debugging mode, for example, Eclipse or IntellJ.